### PR TITLE
Update output order of stack-outputs()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: bash
-script:
-  - ./test/parameter-spec.sh
-notifications:
-  email: false
-  os:
-    - linux
-    - osx

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -518,7 +518,11 @@ stack-outputs() {
 
   aws cloudformation describe-stacks \
     --stack-name ${stack}            \
-    --query 'Stacks[].Outputs[]'     \
+    --query "Stacks[].Outputs[].[
+               OutputKey,
+               OutputValue,
+               Description || ''
+             ]"                      \
     --output text                    |
   column -s$'\t' -t
 }

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -524,6 +524,7 @@ stack-outputs() {
                Description || ''
              ]"                      \
     --output text                    |
+  sort              |
   column -s$'\t' -t
 }
 

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -646,8 +646,8 @@ _bma_stack_diff_params() {
 # variables as local and contain a comment that they will be set by this function.
 #
 _bma_stack_args(){
-  # If we are working from a single argument
-  if [[ $# -eq 1 ]]; then # XXX Don't send through --capabilities
+  # If we are working from a single argument (ignore args starting with `--`)
+  if [[ $# -eq 1 ]] || [[ $2 =~ ^-- ]] ; then
     [[ -n "${BMA_DEBUG:-}" ]] && echo "Single arg magic!"
 
     # XXX Should this be a params file?

--- a/test/stack-spec.sh
+++ b/test/stack-spec.sh
@@ -101,15 +101,15 @@ describe "_bma_stack_args:" "$(
   )"
 
   context "with a stack" "$(
-    expect "$(_bma_stack_args great-app)" to_be "main great-app ./great-app.json "
+    expect "$(_bma_stack_args great-app)" to_be "Resolved arguments: great-app ./great-app.json "
   )"
 
   context "with a template" "$(
-    expect "$(_bma_stack_args great-app.yaml)" to_be "main great-app great-app.yaml ./great-app-params.json"
+    expect "$(_bma_stack_args great-app.yaml)" to_be "Resolved arguments: great-app great-app.yaml ./great-app-params.json"
   )"
 
   context "with a params file" "$(
-    expect "$(_bma_stack_args params/great-app-params-staging.json)" to_be "main great-app-staging ./great-app.json params/great-app-params-staging.json"
+    expect "$(_bma_stack_args params/great-app-params-staging.json)" to_be "Resolved arguments: great-app-staging ./great-app.json params/great-app-params-staging.json"
   )"
 
 )"


### PR DESCRIPTION
Previously, this command displayed any values present.
Given `Description` and `ExportName` are optional, and
`Description` can have spaces it makes more sense to:
- omit `ExportName` (we have stack-exports() for that)
- put `Description` last (as it has spaces and may be long)

```
$ stack-outputs vpc-ratings-reviews-staging | grep Route
RouteTablePrivate1        rtb-XXXXXXXX     The routing table for private subnet 1
RouteTablePrivate2        rtb-XXXXXXXX     The routing table for private subnet 2
RouteTablePublic          rtb-XXXXXXXX     The routing table for public subnets
RouteTableRds             rtb-XXXXXXXX     The routing table for RDS subnets
RouteTableServices        rtb-XXXXXXXX     The routing table for services subnets

```