### PR TITLE
Add support for zsh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+aliases
 lib/load.inc
 multipass-role-arns
 multipass-role-arns/*

--- a/README.md
+++ b/README.md
@@ -39,6 +39,28 @@ Add the bash_completion scripts: (optional)
 $ source ~/.bash-my-aws/bash_completion.sh
 ```
 
+### For non-bash users
+
+NB: If there are new functions, you will need to regenerate the aliases file
+
+Generate the aliases:
+
+```ShellSession
+$ ~/.bash-my-aws/generate_aliases.sh
+```
+
+Source the generated aliases:
+
+```ShellSession
+$ source ~/.bash-my-aws/aliases
+```
+
+And if you use `zsh` and want completion: (optional)
+
+```ShellSession
+$ source ~/.bash-my-aws/zsh_completion.sh
+```
+
 **Typing stack[TAB][TAB] will list available functions for CloudFormation:**
 
 ```ShellSession

--- a/generate_aliases.sh
+++ b/generate_aliases.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# load all the functions from bash-my-aws
+for f in ~/.bash-my-aws/lib/*-functions; do source $f; done
+
+# generate the aliases file
+echo "# GENERATED ALIASES FOR BASH-MY-AWS" > ~/.bash-my-aws/aliases
+echo -e "# to regenerate run: ./generate_aliases.sh \n" >> ~/.bash-my-aws/aliases
+# generate the functions except for functions starting with _
+for fnc in $(compgen -A function | grep -v "_"); do
+  echo "alias $fnc='~/.bash-my-aws/bin/bma $fnc'" >> ~/.bash-my-aws/aliases
+done;

--- a/zsh_completion.sh
+++ b/zsh_completion.sh
@@ -1,0 +1,4 @@
+autoload -U +X compinit && compinit
+autoload -U +X bashcompinit && bashcompinit
+setopt COMPLETE_ALIASES
+source ~/.bash-my-aws/bash_completion.sh


### PR DESCRIPTION
# What 
- create aliases for public functions in bash-my-functions
- invoke the functions using `~/.bash-my-aws/bin/bma`

# Why 
- to invoke bash-my-aws functions as if they are bash scripts

# How
- `./generate_aliases.sh` will generate a list of aliases
- `./zsh_completion.sh` to enable completion on zsh 
- update instructions in `README.md`
