### PR TITLE
Move generate aliases to bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ NB: If there are new functions, you will need to regenerate the aliases file
 Generate the aliases:
 
 ```ShellSession
-$ ~/.bash-my-aws/generate_aliases.sh
+$ ~/.bash-my-aws/bin/generate_aliases
 ```
 
 Source the generated aliases:

--- a/bin/bma_type
+++ b/bin/bma_type
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# load all the functions from bash-my-aws
+for f in ~/.bash-my-aws/lib/*-functions; do source $f; done
+
+# generate the aliases file
+type "$@"

--- a/bin/generate_aliases
+++ b/bin/generate_aliases
@@ -6,6 +6,10 @@ for f in ~/.bash-my-aws/lib/*-functions; do source $f; done
 # generate the aliases file
 echo "# GENERATED ALIASES FOR BASH-MY-AWS" > ~/.bash-my-aws/aliases
 echo -e "# to regenerate run: ./generate_aliases.sh \n" >> ~/.bash-my-aws/aliases
+
+# alias to see the function easily
+echo "alias bma-type='~/.bash-my-aws/bin/bma_type'" >> ~/.bash-my-aws/aliases
+
 # generate the functions except for functions starting with _
 for fnc in $(compgen -A function | grep -v "_"); do
   echo "alias $fnc='~/.bash-my-aws/bin/bma $fnc'" >> ~/.bash-my-aws/aliases


### PR DESCRIPTION
# What 
- move scripts to appropriate folders
- ability to view function definitions for non-bash users

# How 
- move generate aliases to bin folder and removed `.sh`
- add a new script to `bma_type` 
- update `README.md`

# Why 
- the functions are aliases so `type <func_name>` doesn't work