### PR TITLE
[WIP] Break out region-functions from misc-functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Source the generated aliases:
 $ source ~/.bash-my-aws/aliases
 ```
 
+Source region functions:
+
+```ShellSession
+$ source ~/.bash-my-aws/lib/misc-functions
+```
+
 And if you use `zsh` and want completion: (optional)
 
 ```ShellSession

--- a/bin/generate-aliases
+++ b/bin/generate-aliases
@@ -5,8 +5,12 @@ for f in ~/.bash-my-aws/lib/*-functions; do source $f; done
 
 # generate the aliases file
 echo "# GENERATED ALIASES FOR BASH-MY-AWS" > ~/.bash-my-aws/aliases
-echo -e "# to regenerate run: ./generate_aliases.sh \n" >> ~/.bash-my-aws/aliases
+echo -e "# to regenerate run: bin/generate_aliases.sh \n" >> ~/.bash-my-aws/aliases
 # generate the functions except for functions starting with _
-for fnc in $(compgen -A function | grep -v "_"); do
+for fnc in $(compgen -A function); do
   echo "alias $fnc='~/.bash-my-aws/bin/bma $fnc'" >> ~/.bash-my-aws/aliases
 done;
+
+# region() needs to be a function in order to let it set AWS_DEFAULT_REGION
+# in the current shell
+echo "unalias region" >> ~/.bash-my-aws/aliases

--- a/lib/misc-functions
+++ b/lib/misc-functions
@@ -2,6 +2,13 @@
 #
 # miscellaneous functions that don't belong anywhere else
 
+# Returns the Account Alias
+aws-account-alias() {
+  aws iam list-account-aliases \
+    --query AccountAliases     \
+    --output text
+}
+
 # Returns AWS Account ID of caller
 aws-account-id() {
   aws sts get-caller-identity --query Account --output text
@@ -45,34 +52,3 @@ aws-panopticon() {
 columnise() {
   column -s$'\t' -t
 }
-
-regions() {
-  aws ec2 describe-regions           \
-    --query "Regions[].[RegionName]" \
-    --output text                    | 
-  sort
-}
-
-region-each() {
-  local old_aws_default_region="$AWS_DEFAULT_REGION"
-  for AWS_DEFAULT_REGION in $(regions); do
-    eval "$@" | sed "s/$/ #${AWS_DEFAULT_REGION}/"
-  done
-  AWS_DEFAULT_REGION="$old_aws_default_region"
-}
-
-region() {
-  local inputs=$(__bma_read_inputs $@)
-  if [[ -z "$inputs" ]]; then
-    echo "${AWS_DEFAULT_REGION:-'AWS_DEFAULT_REGION not set'}"
-  else
-    AWS_DEFAULT_REGION="$inputs"
-  fi
-}
-
-aws-account-alias() {
-  aws iam list-account-aliases \
-    --query AccountAliases     \
-    --output text
-}
-

--- a/lib/region-functions
+++ b/lib/region-functions
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# region-functions
+#
+# region() must be sourced in order to update the AWS_DEFAULT_REGION
+# environment variable. It cannot set this when run via bin/bma.
+
+region() {
+  local inputs=$(__bma_read_inputs $@)
+  if [[ -z "$inputs" ]]; then
+    echo "${AWS_DEFAULT_REGION:-'AWS_DEFAULT_REGION not set'}"
+  else
+    AWS_DEFAULT_REGION="$inputs"
+  fi
+}
+
+region-each() {
+  local old_aws_default_region="$AWS_DEFAULT_REGION"
+  for AWS_DEFAULT_REGION in $(regions); do
+    eval "$@" | sed "s/$/ #${AWS_DEFAULT_REGION}/"
+  done
+  AWS_DEFAULT_REGION="$old_aws_default_region"
+}
+
+regions() {
+  aws ec2 describe-regions           \
+    --query "Regions[].[RegionName]" \
+    --output text                    |
+  sort
+}
+

--- a/lib/region-functions
+++ b/lib/region-functions
@@ -5,7 +5,7 @@
 # region() must be sourced in order to update the AWS_DEFAULT_REGION
 # environment variable. It cannot set this when run via bin/bma.
 
-region() {
+function region() {
   local inputs=$(__bma_read_inputs $@)
   if [[ -z "$inputs" ]]; then
     echo "${AWS_DEFAULT_REGION:-'AWS_DEFAULT_REGION not set'}"
@@ -14,7 +14,7 @@ region() {
   fi
 }
 
-region-each() {
+function region-each() {
   local old_aws_default_region="$AWS_DEFAULT_REGION"
   for AWS_DEFAULT_REGION in $(regions); do
     eval "$@" | sed "s/$/ #${AWS_DEFAULT_REGION}/"
@@ -22,7 +22,7 @@ region-each() {
   AWS_DEFAULT_REGION="$old_aws_default_region"
 }
 
-regions() {
+function regions() {
   aws ec2 describe-regions           \
     --query "Regions[].[RegionName]" \
     --output text                    |


### PR DESCRIPTION
People calling functions via bin/bma better source region-functions
if they want region() to update AWS_DEFAULT_REGION in their shell.