### PR TITLE
Generate aliases for all functions, including those with _

### DIFF
--- a/bin/generate-aliases
+++ b/bin/generate-aliases
@@ -7,6 +7,6 @@ for f in ~/.bash-my-aws/lib/*-functions; do source $f; done
 echo "# GENERATED ALIASES FOR BASH-MY-AWS" > ~/.bash-my-aws/aliases
 echo -e "# to regenerate run: ./generate_aliases.sh \n" >> ~/.bash-my-aws/aliases
 # generate the functions except for functions starting with _
-for fnc in $(compgen -A function | grep -v "_"); do
+for fnc in $(compgen -A function); do
   echo "alias $fnc='~/.bash-my-aws/bin/bma $fnc'" >> ~/.bash-my-aws/aliases
 done;


### PR DESCRIPTION
No reason to exclude them. It meant `asg-processes_suspended` was missing