### PR TITLE
stacks() allows piping in of stack-names

### DIFF
--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -40,7 +40,8 @@
 # Output sorted by CreationTime
 stacks() {
 
-  local filters=$(__bma_read_filters $@)
+  local filters=$(__bma_read_filters $@) # Filter output by arguments (optional)
+  local stack_names=$(__bma_read_inputs) # Filter by stack-names from STDIN (optional)
 
   aws cloudformation list-stacks                      \
     --stack-status                                    \
@@ -59,7 +60,7 @@ stacks() {
       UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS    \
       UPDATE_ROLLBACK_FAILED                          \
       UPDATE_ROLLBACK_IN_PROGRESS                     \
-    --query "StackSummaries[][
+    --query "StackSummaries[${stack_names:+?contains(['${stack_names// /"','"}'], StackName)}][
                StackName ,
                StackStatus,
                CreationTime,
@@ -70,7 +71,6 @@ stacks() {
   sort -b -k 3          |
   column -s$'\t' -t
 }
-
 
 stack-arn() {
   local stacks=$(__bma_read_inputs $@)


### PR DESCRIPTION
This allow you to view details for a set of stacks output
from another command.

```
$ vpcs | awk '{print $5}' | stacks
vpc-test   UPDATE_COMPLETE  2018-08-01T06:22:14.590Z  2019-06-01T11:28:01.119Z
vpc-test2  UPDATE_COMPLETE  2018-08-06T06:18:01.104Z  2019-06-01T11:28:26.516Z
```