### PR TITLE
Ensure we only use short option for column on OSX

### DIFF
--- a/lib/log-functions
+++ b/lib/log-functions
@@ -11,7 +11,7 @@ log-groups() {
   if column --help | grep -- --table-right > /dev/null; then
     column_command='column --table --table-right 3,4'
   else
-    column_command='column --table'
+    column_command='column -t'
   fi
 
   aws logs describe-log-groups    \


### PR DESCRIPTION
Turns out OSX version of `column` only supports short option names.

This change should make it work for OSX.