### PR TITLE
stacks() indicates whether stack is NESTED or NOT_NESTED

### DIFF
--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -64,7 +64,8 @@ stacks() {
                StackName ,
                StackStatus,
                CreationTime,
-               LastUpdatedTime
+               LastUpdatedTime || 'NEVER_UPDATED',
+               ( RootId && 'NESTED') || ''
              ]"                                       \
     --output text       |
   grep -E -- "$filters" |

--- a/lib/stack-functions
+++ b/lib/stack-functions
@@ -65,7 +65,7 @@ stacks() {
                StackStatus,
                CreationTime,
                LastUpdatedTime || 'NEVER_UPDATED',
-               ( RootId && 'NESTED') || ''
+               ( RootId && 'NESTED') || 'NOT_NESTED'
              ]"                                       \
     --output text       |
   grep -E -- "$filters" |


### PR DESCRIPTION
> Certain stack operations, such as stack updates, should be initiated from the root stack rather than performed directly on nested stacks themselves.
[AWS - Working with Nested Stacks](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-nested-stacks.html)