### PR TITLE
instance-{start,stop}: replace JSON output with lines

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -326,38 +326,11 @@ Get IP Addresses for EC2 instances
 
 Start some existing stopped EC2 instances.
 
-*This could probably do with some line oriented output.*
-
 `USAGE: instance-stop instance-id [instance-id]`
 
-
     $ instances postgres | instance-start
-    {
-        "StartingInstances": [
-            {
-                "CurrentState": {
-                    "Code": 0,
-                    "Name": "pending"
-                },
-                "InstanceId": "i-89cefa9403373d7a5",
-                "PreviousState": {
-                    "Code": 16,
-                    "Name": "running"
-                }
-            },
-            {
-                "CurrentState": {
-                    "Code": 0,
-                    "Name": "pending"
-                },
-                "InstanceId": "i-806d8f1592e2a2efd",
-                "PreviousState": {
-                    "Code": 16,
-                    "Name": "running"
-                }
-            }
-        ]
-    }
+    i-a8b8dd6783e1a40cc  PreviousState=stopped  CurrentState=pending
+    i-5d74753e210bfe04d  PreviousState=stopped  CurrentState=pending
 
 
 ### instance-state
@@ -381,37 +354,12 @@ Get current state of instances.
 
 Stop EC2 instances
 
-*This could probably do with some line oriented output.*
-
 `USAGE: instance-stop instance-id [instance-id]`
 
     $ instances postgres | instance-stop
-    {
-        "StoppingInstances": [
-            {
-                "CurrentState": {
-                    "Code": 64,
-                    "Name": "stopping"
-                },
-                "InstanceId": "i-89cefa9403373d7a5",
-                "PreviousState": {
-                    "Code": 16,
-                    "Name": "running"
-                }
-            },
-            {
-                "CurrentState": {
-                    "Code": 64,
-                    "Name": "stopping"
-                },
-                "InstanceId": "i-806d8f1592e2a2efd",
-                "PreviousState": {
-                    "Code": 16,
-                    "Name": "running"
-                }
-            }
-        ]
-    }
+
+    i-a8b8dd6783e1a40cc  PreviousState=running  CurrentState=stopping
+    i-5d74753e210bfe04d  PreviousState=running  CurrentState=stopping
 
 
 ### instance-tags

--- a/lib/instance-functions
+++ b/lib/instance-functions
@@ -225,7 +225,16 @@ instance-start() {
   local instance_ids="$(__bma_read_inputs $@)"
   [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
 
-  aws ec2 start-instances --instance-ids $instance_ids
+  aws ec2 start-instances        \
+    --instance-ids $instance_ids \
+    --output text                \
+    --query "
+      StartingInstances[].[
+        InstanceId,
+        join('=', ['PreviousState', PreviousState.Name]),
+        join('=', ['CurrentState', CurrentState.Name])]
+    " |
+    column -t
 }
 
 instance-state() {
@@ -251,7 +260,16 @@ instance-stop() {
   local instance_ids="$(__bma_read_inputs $@)"
   [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
 
-  aws ec2 stop-instances --instance-ids $instance_ids
+  aws ec2 stop-instances         \
+    --instance-ids $instance_ids \
+    --output text                \
+    --query "
+      StoppingInstances[].[
+        InstanceId,
+        join('=', ['PreviousState', PreviousState.Name]),
+        join('=', ['CurrentState', CurrentState.Name])]
+    " |
+    column -t
 }
 
 # Replaces two older functions


### PR DESCRIPTION
Nice example of documentation driven development.

These were old commands and the output didn't look right in the new world.