### PR TITLE
instance-terminate: change from JSON to line output

### DIFF
--- a/cloudformation/ec2.yml
+++ b/cloudformation/ec2.yml
@@ -5,8 +5,9 @@ Parameters:
     Description: EC2 Instance Type to use
     Default: t3.nano
   LatestAmiId:
-    Type: string
-    Default: ami-123456789012 # XXX for localstack
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
+    # Default: ami-123456789012 # XXX for localstack
   KeyName:
     Type: String
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -429,44 +429,33 @@ Stop EC2 instances
 
 ### instance-terminate
 
-Terminate EC2 instance.
-
-*This could probably do with some line oriented output.*
+Terminate EC2 instance(s).
 
 `USAGE: instance-terminate instance-id [instance-id]`
 
-    $ instances | head -1 | instance-terminate
-    You are about to terminate the following instances:
-    i-4e15ece1de1a3f869  ami-123456789012  t3.nano  running  nagios  2019-12-10T08:17:18.000Z  ap-southeast-2a  None
-    Are you sure you want to continue? y
-
-    {
-        "TerminatingInstances": [
-            {
-                "CurrentState": {
-                    "Code": 32,
-                    "Name": "shutting-down"
-                },
-                "InstanceId": "i-4e15ece1de1a3f869",
-                "PreviousState": {
-                    "Code": 16,
-                    "Name": "running"
-                }
-            }
-        ]
-    }
-
+```shell
+$ instances | head -3 | instance-terminate
+You are about to terminate the following instances:
+i-01c7edb986c18c16a  ami-0119aa4d67e59007c  t3.nano  terminated  asg2  2019-12-13T03:37:51.000Z  ap-southeast-2c  None
+i-012dded46894dfa04  ami-0119aa4d67e59007c  t3.nano  running     ec2   2019-12-13T10:12:55.000Z  ap-southeast-2b  vpc-deb8edb9
+Are you sure you want to continue? y
+i-06ee900565652ecc5  PreviousState=terminated  CurrentState=terminated
+i-01c7edb986c18c16a  PreviousState=terminated  CurrentState=terminated
+i-012dded46894dfa04  PreviousState=running     CurrentState=shutting-down
+```
 
 
 ### instance-termination-protection
 
 `USAGE: instance-termination-protection instance-id [instance-id]`
 
-    $ instances | instance-termination-protection
-    i-4e15ece1de1a3f869	DisableApiTermination=true
-    i-89cefa9403373d7a5	DisableApiTermination=false
-    i-806d8f1592e2a2efd	DisableApiTermination=false
-    i-61e86ac6be1e2c193	DisableApiTermination=false
+```shell
+$ instances | instance-termination-protection
+i-4e15ece1de1a3f869	DisableApiTermination=true
+i-89cefa9403373d7a5	DisableApiTermination=false
+i-806d8f1592e2a2efd	DisableApiTermination=false
+i-61e86ac6be1e2c193	DisableApiTermination=false
+```
 
 
 ### instance-termination-protection-disable

--- a/lib/instance-functions
+++ b/lib/instance-functions
@@ -297,6 +297,7 @@ instance-terminate() {
   local instance_ids="$(__bma_read_inputs $@)"
   [[ -z "$instance_ids" ]] && __bma_usage "instance-id [instance-id]" && return 1
 
+
   echo "You are about to terminate the following instances:"
   instances "$instance_ids"
   [ -t 0 ] || exec </dev/tty # reattach keyboard to STDIN
@@ -305,7 +306,16 @@ instance-terminate() {
   echo
   if [[ $REPLY =~ $regex_yes ]]
   then
-    aws ec2 terminate-instances --instance-ids $instance_ids
+    aws ec2 terminate-instances    \
+      --instance-ids $instance_ids \
+      --output text                \
+      --query "
+        TerminatingInstances[].[
+          InstanceId,
+          join('=', ['PreviousState', PreviousState.Name]),
+          join('=', ['CurrentState', CurrentState.Name])]
+      " |
+      column -t
   fi
 }
 


### PR DESCRIPTION
Use line oriented output instead of JSON.

This function is old and benefited from some documentation driven development. 