### PR TITLE
Add Google Analytics for https://bash-my-aws.org (explanation below)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: 'bash-my-aws'
 site_description: 'CLI Tools for Managing AWS'
 site_author: 'Mike Bailey'
 site_url: 'https://bash-my-aws.github.io/'
+google_analytics: ['UA-9713294-2', 'bash-my-aws.org']
 
 nav:
   - Home: index.md


### PR DESCRIPTION
I'm putting a lot of time into writing documentation and am really
curious how many people are benefiting from it.

I use Firefox web browser with tracking protection turned on and
believe it doesn't call out to Google Analytics (I did a quick test).

If you know of a free tracking tool that respects privacy then
please let me know.